### PR TITLE
Add detailed build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@
 JDEE Java backend
 
 # Building:
-1. It requires *Maven 3*
-2. ```mvn -DskipTests=true assembly:assembly```
+[Maven 3](https://maven.apache.org/) is required to build jdee-server. You will need to clone jdee-server from git, run the build, copy the jdee-bundle.jar to a new directory, and point ```jdee-server-dir``` variable in Emacs to the directory containing the jar.
 
-Copy ```target/jdee-bundle-${version}.jar``` to a directory and customize ```jdee-server-dir``` to point to the dir.
+1. Install Maven (if you don't already have it)
+2. At the terminal enter the following commands in a directory of your choice:
+3. ```$ git clone https://github.com/jdee-emacs/jdee-server.git```
+4. ```$ cd jdee-server```
+5. ```$ mvn -DskipTests=true assembly:assembly```
+6. Copy ```target/jdee-bundle-${version}.jar``` to a directory of your choice (e.g. ```~/myJars```)
+7. Start Emacs and enter the following commands:
+8. ```M-x customize```
+9. In the search field enter ```jdee-server-dir```
+10. In the field next to "Jdee Server Dir:" enter the directory holding the jar from step 6 (e.g. ```~/myJars```)
+11. Click the "Apply and Save" button


### PR DESCRIPTION
When building the jdee-server, I felt the instructions in the README were too vague, and I had to guess the missing steps in between. I added more detailed step-by-step instructions so that others might find the process easier than I did. Let me know what you think. 