### PR TITLE
Fix a Maven warning and disable compiler warning for missing serialVersionUID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,9 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
-                    <compilerArgument>-Xlint:all</compilerArgument>
+                    <compilerArgs>
+                        <arg>-Xlint:all,-serial</arg>
+                    </compilerArgs>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,10 @@
     <name>JDEE Server</name>
     <url>https://github.com/jdee-emacs/jdee-server</url>
 
-    <prerequisites>
-        <maven>3.0.0</maven>
-    </prerequisites>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.7</java.version>
+        <required.maven.version>3.0.0</required.maven.version>
     </properties>
 
     <dependencies>
@@ -65,6 +62,26 @@
                         <goals>
                             <goal>single</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>${required.maven.version}</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Maven instructs to use maven-enforcer-plugin so I did so.

The choice to not explicitly define serialVersionUID is evidently conscious so the compiler should not warn us about it. I added a flag to disable that warning.