### PR TITLE
LispWriter refactor

### DIFF
--- a/src/main/java/jde/juci/LispWriter.java
+++ b/src/main/java/jde/juci/LispWriter.java
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2002 by Nick Sieger
- *
- * $Revision: 1.1 $
- * $Date: 2003/02/15 20:58:26 $
+ * Copyright 2021 Jaakko Linnosaari
  *
  * Author: Nick Sieger <nsieger@bitstream.net>
  *
@@ -26,7 +24,7 @@ package jde.juci;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -53,7 +51,7 @@ public class LispWriter {
      */
     public static final Quoted NULL = new Quoted(new Symbol("null"));
 
-    private PrintWriter output;
+    private final PrintWriter output;
     private boolean autoQuoteLists = true;
     private boolean inQuote = false;
 
@@ -72,7 +70,7 @@ public class LispWriter {
         this.autoQuoteLists = autoQuoteLists;
     }
 
-    public void writeList(List<Cons> list) {
+    public void writeList(Collection<?> list) {
         if (isAutoQuoteLists() && !inQuote) {
             output.write("'");
             inQuote = true;
@@ -83,19 +81,18 @@ public class LispWriter {
         }
     }
 
-    public void writeForm(List<Cons> list) {
+    public void writeForm(Collection<?> c) {
         output.print("(");
-        for (int i = 0; i < list.size(); i++) {
-            if (i > 0) {
+        for (Iterator<?> i = c.iterator(); i.hasNext();) {
+            writeUnknown(i.next());
+            if (i.hasNext())
                 output.print(" ");
-            }
-            writeUnknown(list.get(i));
         }
         output.print(")");
     }
 
     public void writeAlist(Map<Object, Object> map) {
-        List<Cons> alist = new ArrayList<Cons>();
+        Collection<Cons> alist = new ArrayList<>();
         for (Map.Entry<Object, Object> e : map.entrySet()) {
             alist.add(new Cons(e.getKey(), e.getValue()));
         }
@@ -252,7 +249,7 @@ public class LispWriter {
         if (o instanceof Number) {
             writeNumber((Number) o);
         } else if (o instanceof Collection) {
-            writeList(new ArrayList((Collection) o));
+            writeList((Collection) o);
         } else if (o instanceof Map) {
             writeAlist((Map) o);
         } else if (o instanceof Cons) {

--- a/src/main/java/jde/juci/LispWriter.java
+++ b/src/main/java/jde/juci/LispWriter.java
@@ -149,32 +149,16 @@ public class LispWriter {
         output.write(Integer.toString(n));
     }
 
-    public void writeInt(Integer n) {
-        writeInt(n.intValue());
-    }
-
     public void writeLong(long n) {
         output.write(Long.toString(n));
-    }
-
-    public void writeLong(Long n) {
-        writeLong(n.longValue());
     }
 
     public void writeFloat(float f) {
         output.write(Float.toString(f));
     }
 
-    public void writeFloat(Float f) {
-        writeFloat(f.floatValue());
-    }
-
     public void writeDouble(double d) {
         output.write(Double.toString(d));
-    }
-
-    public void writeDouble(Double d) {
-        writeDouble(d.doubleValue());
     }
 
     public void writeChar(char c) {
@@ -223,10 +207,6 @@ public class LispWriter {
         } else {
             writeNil();
         }
-    }
-
-    public void writeBoolean(Boolean b) {
-        writeBoolean(b.booleanValue());
     }
 
     public void writeT() {

--- a/src/test/java/jde/juci/LispWriterTest.java
+++ b/src/test/java/jde/juci/LispWriterTest.java
@@ -52,8 +52,8 @@ public class LispWriterTest {
 
     @Test
     public void testWriteString() {
-        lwriter.writeString("\"abc\'\\\ndef\b\r\t\f");
-        assertEquals("\"\\\"abc\\\'\\\\\\ndef\\b\\r\\t\\f\"", output.toString());
+        lwriter.writeString("\"abc'\\\ndef\b\r\t\f");
+        assertEquals("\"\\\"abc\\'\\\\\\ndef\\b\\r\\t\\f\"", output.toString());
     }
 
     @Test
@@ -67,28 +67,28 @@ public class LispWriterTest {
 
     @Test
     public void testIntObject() {
-        lwriter.writeInt(new Integer(1010));
+        lwriter.writeInt(Integer.valueOf(1010));
         assertEquals("1010", output.toString());
         reset();
-        lwriter.writeUnknown(new Integer(1010));
+        lwriter.writeUnknown(Integer.valueOf(1010));
         assertEquals("1010", output.toString());
     }
 
     @Test
     public void testLongPrimitive() {
-        lwriter.writeLong(101020203030l);
+        lwriter.writeLong(101020203030L);
         assertEquals("101020203030", output.toString());
         reset();
-        lwriter.writeUnknown(101020203030l);
+        lwriter.writeUnknown(101020203030L);
         assertEquals("101020203030", output.toString());
     }
 
     @Test
     public void testLongObject() {
-        lwriter.writeLong(new Long(101020203030l));
+        lwriter.writeLong(Long.valueOf(101020203030L));
         assertEquals("101020203030", output.toString());
         reset();
-        lwriter.writeUnknown(new Long(101020203030l));
+        lwriter.writeUnknown(Long.valueOf(101020203030L));
         assertEquals("101020203030", output.toString());
     }
 
@@ -103,10 +103,10 @@ public class LispWriterTest {
 
     @Test
     public void testFloatObject() {
-        lwriter.writeFloat(new Float(10.1f));
+        lwriter.writeFloat(Float.valueOf(10.1f));
         assertEquals("10.1", output.toString());
         reset();
-        lwriter.writeUnknown(new Float(10.1f));
+        lwriter.writeUnknown(Float.valueOf(10.1f));
         assertEquals("10.1", output.toString());
     }
 
@@ -121,10 +121,10 @@ public class LispWriterTest {
 
     @Test
     public void testDoubleObject() {
-        lwriter.writeDouble(new Double(10.1d));
+        lwriter.writeDouble(Double.valueOf(10.1d));
         assertEquals("10.1", output.toString());
         reset();
-        lwriter.writeUnknown(new Double(10.1d));
+        lwriter.writeUnknown(Double.valueOf(10.1d));
         assertEquals("10.1", output.toString());
     }
 
@@ -165,20 +165,20 @@ public class LispWriterTest {
         lwriter.writeChar('\r');
         lwriter.writeChar('\t');
         lwriter.writeChar('\f');
-        assertEquals("?a?\\\"?\\\'?\\\\?\\??\\)?\\(?\\]?\\[?\\n?\\b?\\r?\\t?\\f",
+        assertEquals("?a?\\\"?\\'?\\\\?\\??\\)?\\(?\\]?\\[?\\n?\\b?\\r?\\t?\\f",
                      output.toString());
     }
 
     @Test
     public void testWriteCharObject() {
-        lwriter.writeChar(new Character('b'));
-        lwriter.writeChar(new Character('a'));
-        lwriter.writeChar(new Character('z'));
-        lwriter.writeChar(new Character('\n'));
-        lwriter.writeChar(new Character('\''));
-        lwriter.writeChar(new Character('\t'));
-        lwriter.writeUnknown(new Character('f'));
-        assertEquals("?b?a?z?\\n?\\\'?\\t?f", output.toString());
+        lwriter.writeChar(Character.valueOf('b'));
+        lwriter.writeChar(Character.valueOf('a'));
+        lwriter.writeChar(Character.valueOf('z'));
+        lwriter.writeChar(Character.valueOf('\n'));
+        lwriter.writeChar(Character.valueOf('\''));
+        lwriter.writeChar(Character.valueOf('\t'));
+        lwriter.writeUnknown(Character.valueOf('f'));
+        assertEquals("?b?a?z?\\n?\\'?\\t?f", output.toString());
     }
 
     @Test
@@ -190,21 +190,21 @@ public class LispWriterTest {
 
     @Test
     public void testBooleanObject() {
-        lwriter.writeBoolean(new Boolean(true));
-        lwriter.writeBoolean(new Boolean(false));
-        lwriter.writeUnknown(new Boolean(true));
+        lwriter.writeBoolean(Boolean.TRUE);
+        lwriter.writeBoolean(Boolean.FALSE);
+        lwriter.writeUnknown(Boolean.TRUE);
         assertEquals("tnilt", output.toString());
     }
 
     @Test
     public void testWriteNull() {
         lwriter.writeUnknown(null);
-        assertEquals("\'null", output.toString());
+        assertEquals("'null", output.toString());
     }
 
     @Test
     public void testForm1() {
-        List l = Arrays.asList(
+        List<Object> l = Arrays.asList(
                 new Symbol("message"), "Hello %s", new Symbol("user-full-name"));
         lwriter.writeForm(l);
         assertEquals("(message \"Hello %s\" user-full-name)", output.toString());
@@ -215,7 +215,7 @@ public class LispWriterTest {
 
     @Test
     public void testWriteUnknowWithACollection() {
-        Collection<Object> c = new ArrayDeque();
+        Collection<Object> c = new ArrayDeque<>();
         c.add(new Symbol("message"));
         c.add("Hello %s");
         c.add(new Symbol("user-full-name"));
@@ -225,12 +225,12 @@ public class LispWriterTest {
 
     @Test
     public void testQuoted1() {
-        List l = new ArrayList();
+        List<Object> l = new ArrayList<>();
         l.add(new Symbol("apply"));
         l.add(new Quoted(new Symbol("+")));
         l.add(1);
         l.add(2);
-        List inner = new ArrayList();
+        List<Object> inner = new ArrayList<>();
         inner.add(3);
         inner.add(4);
         l.add(new Quoted(inner));
@@ -247,10 +247,10 @@ public class LispWriterTest {
 
     @Test
     public void testWriteJdeeJuciInvokeElispForm() {
-        List eval = new ArrayList();
+        List<Object> eval = new ArrayList<>();
         eval.add(new Symbol("jdee-juci-invoke-elisp"));
 
-        List form = new ArrayList();
+        List<Object> form = new ArrayList<>();
         form.add(new Symbol("message"));
         form.addAll(Arrays.asList("hello %s", "nick"));
 


### PR DESCRIPTION
The method signatures for writeList and writeForm did not seem to match even the way they were used by the unit tests. I refactored the methods to use generics and eliminated all raw types from tests also.

I cleaned the clutter of unnecessary methods to unbox the different Number objects.

Tests still pass, cover 100% of LispWriter's methods and I was also now able to write them in a way that doesn't evoke compiler warnings.